### PR TITLE
Fix loading tokenizers from s3

### DIFF
--- a/torchTextClassifiers/tokenizers/base.py
+++ b/torchTextClassifiers/tokenizers/base.py
@@ -103,6 +103,11 @@ class BaseTokenizer(ABC):
     def __call__(self, text: Union[str, List[str]], **kwargs) -> list:
         return self.tokenize(text, **kwargs)
 
+    @classmethod
+    @abstractmethod
+    def load_from_s3(cls, s3_path: str, filesystem):
+        pass
+
 
 class HuggingFaceTokenizer(BaseTokenizer):
     def __init__(

--- a/torchTextClassifiers/tokenizers/base.py
+++ b/torchTextClassifiers/tokenizers/base.py
@@ -178,17 +178,14 @@ class HuggingFaceTokenizer(BaseTokenizer):
     @classmethod
     def load_from_s3(cls, s3_path: str, filesystem):
         if filesystem.exists(s3_path) is False:
-            raise FileNotFoundError(
-                f"Tokenizer not found at {s3_path}. Please train it first (see src/train_tokenizers)."
-            )
+            raise FileNotFoundError(f"Tokenizer not found at {s3_path}.")
 
         with filesystem.open(s3_path, "rb") as f:
             json_str = f.read().decode("utf-8")
 
         tokenizer_obj = Tokenizer.from_str(json_str)
-        tokenizer = PreTrainedTokenizerFast(tokenizer_object=tokenizer_obj)
-        instance = cls(vocab_size=len(tokenizer), trained=True)
-        instance.tokenizer = tokenizer
+        instance = cls(vocab_size=tokenizer_obj.get_vocab_size(), trained=True)
+        instance.tokenizer = tokenizer_obj
         instance._post_training()
         return instance
 

--- a/torchTextClassifiers/tokenizers/ngram.py
+++ b/torchTextClassifiers/tokenizers/ngram.py
@@ -432,11 +432,24 @@ class NGramTokenizer(BaseTokenizer):
         print(f"✓ Tokenizer saved to {save_directory}")
 
     @classmethod
-    def from_pretrained(cls, directory: str):
+    def load_from_s3(cls, s3_path: str, filesystem):
         """Load tokenizer from saved configuration."""
-        with open(f"{directory}/tokenizer.json", "r") as f:
-            config = json.load(f)
 
+        config = json.load(filesystem.open(s3_path, "r"))
+        tokenizer = cls.build_from_config(config)
+        return tokenizer
+
+    @classmethod
+    def load(cls, path: str):
+        """Load tokenizer from saved configuration."""
+
+        with open(path, "r") as f:
+            config = json.load(f)
+        tokenizer = cls.build_from_config(config)
+        return tokenizer
+
+    @classmethod
+    def build_from_config(cls, config):
         tokenizer = cls(
             min_count=config["min_count"],
             min_n=config["min_n"],
@@ -468,5 +481,4 @@ class NGramTokenizer(BaseTokenizer):
         )
         print("✓ Subword cache built")
 
-        print(f"✓ Tokenizer loaded from {directory}")
         return tokenizer


### PR DESCRIPTION
This pull request introduces improvements to the tokenizer loading and saving logic, particularly around loading from S3 and configuration-based instantiation. The changes add a unified `load_from_s3` interface to the tokenizer base class, refactor the S3 loading implementation for HuggingFace and NGram tokenizers, and introduce a `build_from_config` method for NGram tokenizers to streamline instantiation from configuration files.

**Tokenizer loading improvements:**

* Added an abstract `load_from_s3` class method to `BaseTokenizer` to enforce a consistent S3 loading interface across all tokenizer subclasses.
* Refactored the `HuggingFaceTokenizer.load_from_s3` method to simplify error messages and ensure the correct tokenizer object is instantiated from S3.
* Implemented `load_from_s3` for `NGramTokenizer`, allowing loading from S3 using the provided filesystem and configuration, and refactored the loading logic for clarity.

**Configuration-based instantiation:**

* Added a `build_from_config` class method to `NGramTokenizer` to streamline tokenizer creation from a configuration dictionary, and refactored existing loading methods to use this new method.
* Removed redundant print statement from the NGram tokenizer's loading logic for cleaner output.