### PR TITLE
Fix label att parametrization

### DIFF
--- a/torchTextClassifiers/torchTextClassifiers.py
+++ b/torchTextClassifiers/torchTextClassifiers.py
@@ -50,11 +50,11 @@ class ModelConfig:
     """Base configuration class for text classifiers."""
 
     embedding_dim: int
+    num_classes: int
     categorical_vocabulary_sizes: Optional[List[int]] = None
     categorical_embedding_dims: Optional[Union[List[int], int]] = None
-    num_classes: Optional[int] = None
     attention_config: Optional[AttentionConfig] = None
-    label_attention_config: Optional[LabelAttentionConfig] = None
+    n_heads_label_attention: Optional[int] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -142,7 +142,7 @@ class torchTextClassifiers:
         self.embedding_dim = model_config.embedding_dim
         self.categorical_vocabulary_sizes = model_config.categorical_vocabulary_sizes
         self.num_classes = model_config.num_classes
-        self.enable_label_attention = model_config.label_attention_config is not None
+        self.enable_label_attention = model_config.n_heads_label_attention is not None
 
         if self.tokenizer.output_vectorized:
             self.text_embedder = None
@@ -156,7 +156,10 @@ class torchTextClassifiers:
                 embedding_dim=self.embedding_dim,
                 padding_idx=tokenizer.padding_idx,
                 attention_config=model_config.attention_config,
-                label_attention_config=model_config.label_attention_config,
+                label_attention_config=LabelAttentionConfig(
+                    n_head=model_config.n_heads_label_attention,
+                    num_classes=model_config.num_classes,
+                ),
             )
             self.text_embedder = TextEmbedder(
                 text_embedder_config=text_embedder_config,
@@ -697,10 +700,6 @@ class torchTextClassifiers:
 
         # Reconstruct model_config
         model_config = ModelConfig.from_dict(metadata["model_config"])
-        if isinstance(model_config.label_attention_config, dict):
-            model_config.label_attention_config = LabelAttentionConfig(
-                **model_config.label_attention_config
-            )
 
         # Create instance
         instance = cls(


### PR DESCRIPTION
This pull request updates the handling of label attention configuration and tokenizer saving in the `torchTextClassifiers` codebase. The main changes simplify and clarify how label attention is configured and instantiated, and ensure compatibility with the tokenizer saving method.

**Label Attention Configuration Updates:**

* The `ModelConfig` class now uses `n_heads_label_attention` (an integer) instead of the previous `label_attention_config` object, and makes `num_classes` a required field. This simplifies configuration and ensures that the number of classes is always specified.
* The model initialization now enables label attention if `n_heads_label_attention` is set, rather than checking for a full config object.
* When constructing the `TextEmbedderConfig`, a new `LabelAttentionConfig` is created on the fly using `n_heads_label_attention` and `num_classes` from the model config, instead of passing through a possibly pre-existing config object.
* The model loading logic no longer attempts to reconstruct `label_attention_config` from a dictionary, since label attention is now configured via `n_heads_label_attention`.

**Tokenizer Saving:**

* The tokenizer is now saved using the `save_pretrained` method instead of `save`, ensuring compatibility with Hugging Face-style tokenizers.